### PR TITLE
scrot supports strftime notations directly

### DIFF
--- a/.i3/config
+++ b/.i3/config
@@ -150,14 +150,14 @@ bindsym XF86AudioPrev exec --no-startup-id dbus-send --print-reply --dest=org.mp
 # With $mod:  Interactively select window or rectangle.
 # With Shift: JPEG instead of PNG.
 # With Ctrl:  Sleep 5 seconds before doing the screenshot.
-bindsym                Print               exec --no-startup-id            scrot    "$HOME/tmp/Screenshot $(date '+%Y-%m-%d %H-%M-%S %z').png"
-bindsym                Shift+Print         exec --no-startup-id            scrot    "$HOME/tmp/Screenshot $(date '+%Y-%m-%d %H-%M-%S %z').jpg"
-bindsym --release $mod+Print               exec --no-startup-id            scrot -s "$HOME/tmp/Screenshot $(date '+%Y-%m-%d %H-%M-%S %z').png"
-bindsym --release $mod+Shift+Print         exec --no-startup-id            scrot -s "$HOME/tmp/Screenshot $(date '+%Y-%m-%d %H-%M-%S %z').jpg"
-bindsym                Control+Print       exec --no-startup-id sleep 5 && scrot    "$HOME/tmp/Screenshot $(date '+%Y-%m-%d %H-%M-%S %z').png"
-bindsym                Control+Shift+Print exec --no-startup-id sleep 5 && scrot    "$HOME/tmp/Screenshot $(date '+%Y-%m-%d %H-%M-%S %z').jpg"
-bindsym --release $mod+Control+Print       exec --no-startup-id sleep 5 && scrot -s "$HOME/tmp/Screenshot $(date '+%Y-%m-%d %H-%M-%S %z').png"
-bindsym --release $mod+Control+Shift+Print exec --no-startup-id sleep 5 && scrot -s "$HOME/tmp/Screenshot $(date '+%Y-%m-%d %H-%M-%S %z').jpg"
+bindsym                Print               exec --no-startup-id            scrot    "$HOME/tmp/Screenshot %Y-%m-%d %H-%M-%S %z.png"
+bindsym                Shift+Print         exec --no-startup-id            scrot    "$HOME/tmp/Screenshot %Y-%m-%d %H-%M-%S %z.jpg"
+bindsym --release $mod+Print               exec --no-startup-id            scrot -s "$HOME/tmp/Screenshot %Y-%m-%d %H-%M-%S %z.png"
+bindsym --release $mod+Shift+Print         exec --no-startup-id            scrot -s "$HOME/tmp/Screenshot %Y-%m-%d %H-%M-%S %z.jpg"
+bindsym                Control+Print       exec --no-startup-id sleep 5 && scrot    "$HOME/tmp/Screenshot %Y-%m-%d %H-%M-%S %z.png"
+bindsym                Control+Shift+Print exec --no-startup-id sleep 5 && scrot    "$HOME/tmp/Screenshot %Y-%m-%d %H-%M-%S %z.jpg"
+bindsym --release $mod+Control+Print       exec --no-startup-id sleep 5 && scrot -s "$HOME/tmp/Screenshot %Y-%m-%d %H-%M-%S %z.png"
+bindsym --release $mod+Control+Shift+Print exec --no-startup-id sleep 5 && scrot -s "$HOME/tmp/Screenshot %Y-%m-%d %H-%M-%S %z.jpg"
 
 # Start i3bar to display a workspace bar (plus the system information i3status
 # finds out, if available)


### PR DESCRIPTION
thanks for the useful screenshot bindings. Scrot understands strftime notations directly, so there’s no need to manually call `date`.
